### PR TITLE
Fix formatting for CVE_2006_6979.yml and CVE_2023_30614.yml

### DIFF
--- a/bulletin/CVE_2006_6979.yml
+++ b/bulletin/CVE_2006_6979.yml
@@ -16,5 +16,4 @@ message: |-
 check_family: :bulletin
 vulnerable_version_array:
 - :name: 'amarok'
-:invalid:true
-
+  :invalid: true

--- a/bulletin/CVE_2023_30614.yml
+++ b/bulletin/CVE_2023_30614.yml
@@ -16,4 +16,4 @@ message: |-
 check_family: :bulletin
 vulnerable_version_array:
 - :name: 'rails'
-    :versionEndExcluding: 6.3.2
+  :versionEndExcluding: 6.3.2


### PR DESCRIPTION
YAML errors are preventing running latest dawn scan with KB [v20230512](https://github.com/thesp0nge/dawnscanner_knowledge_base/releases/tag/v20230512) from running as expected due to the following errors:

```
ERROR (dawn): (/root/dawnscanner/kb/bulletin/CVE_2006_6979.yml): could not find expected ':' while scanning a simple key at line 19 column 3
ERROR (dawn): (/root/dawnscanner/kb/bulletin/CVE_2023_30614.yml): did not find expected key while parsing a block mapping at line 18 column 3
```

Linting the files shows that the YAML formatting is incorrect, causing the CVE_2006_6979.yml and CVE_2023_30614.yml to be un-parseable.

This corrects the YAML formatting issues to avoid these errors.